### PR TITLE
Query factories

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,36 +2,6 @@
 
 ## sofa
 
-### Query
-
-* query factories
-
-``` javascript
-// queries/view-by-key.js
-export default opts => {
-  let { ddoc, view key } = opts;
-  let keyPath = `model.${key}`;
-  return Query.extend({
-    find: computed(keyPath, function() {
-      let value = model.get(keyPath);
-      return {
-        ddoc,
-        view,
-        key: value
-      };
-    }).readOnly()
-  });
-}
-
-// relationships/blog-entries.js
-// blog hasMany blog-entry
-export default Relationship.extend({
-
-  query: { name: 'view-by-key', ddoc: 'blog-entry', view: 'by-blog', key: 'model.docId' }
-
-});
-```
-
 ### Relationship classes
 
 * sortable relationship helper `Relationship.extend({ sortable: sortable('position') })`: needed?

--- a/addon/store/store-query-class.js
+++ b/addon/store/store-query-class.js
@@ -23,9 +23,10 @@ export default Ember.Mixin.create({
     return false;
   },
 
-  _queryClassForName(queryName, variantName, variantFn) {
-    Ember.assert(`query variant name is required`, !!variantName);
+  _queryClassForName(queryName, factoryOptions, variantName, variantFn) {
+    assert(`query variant name is required`, !!variantName);
     return this._classForName('query', queryName, variantName, (Query, normalizedModelName) => {
+      console.log(typeof Query);
       assert(`query '${normalizedModelName}' must be sofa Query`, this._isQueryClass(Query));
       let Extended = Query.extend();
       Extended.reopenClass({ store: this, [__sofa_type__]: __sofa_query_type__ });

--- a/addon/store/store-query.js
+++ b/addon/store/store-query.js
@@ -23,13 +23,13 @@ export default Ember.Mixin.create({
     };
   },
 
-  _createQuery({ query, variant, props}) {
+  _createQuery({ query, variant, properties}) {
     let { name, factory } = this._buildQueryFactoryOptions(query);
     return this._queryClassForName({
       name,
       factory,
       variant
-    })._create(props);
+    })._create(properties);
   },
 
   _createQueryForRelation(_relation, variant) {
@@ -41,7 +41,7 @@ export default Ember.Mixin.create({
     return this._createQuery({
       query,
       variant,
-      props: { _relation }
+      properties: { _relation }
     });
   },
 
@@ -54,7 +54,7 @@ export default Ember.Mixin.create({
     return this._createQuery({
       query,
       variant,
-      props: { _internalCollection }
+      properties: { _internalCollection }
     });
   }
 

--- a/addon/store/store-query.js
+++ b/addon/store/store-query.js
@@ -1,8 +1,30 @@
 import Ember from 'ember';
 
+const {
+  copy
+} = Ember;
+
 export default Ember.Mixin.create({
 
-  _createQueryForName({ name, factory, variant, props}) {
+  _buildQueryFactoryOptions(query) {
+    if(typeof query === 'string') {
+      return {
+        name: query
+      };
+    }
+
+    let factory = copy(query);
+    let name = factory.name;
+    delete factory.name;
+
+    return {
+      name,
+      factory
+    };
+  },
+
+  _createQuery({ query, variant, props}) {
+    let { name, factory } = this._buildQueryFactoryOptions(query);
     return this._queryClassForName({
       name,
       factory,
@@ -10,36 +32,14 @@ export default Ember.Mixin.create({
     })._create(props);
   },
 
-  // _buildQueryFactoryOptions(query) {
-  //   if(typeof query === 'string') {
-  //     return {
-  //       name: query
-  //     };
-  //   };
-  //   return query;
-  // },
-
-  // _queryIdentifier(variant, opts) {
-  //   return `${variant} ${JSON.stringify(opts)}`;
-  // },
-
-  // _createQuery(query, props, variant, fn) {
-  //   let opts = merge({}, this._buildQueryFactoryOptions(query));
-  //   let name = opts.name;
-  //   delete opts.name;
-  //   // variant = this._queryIdentifier(variant, opts);
-  //   return this._createQueryForName(name, props, variant, fn);
-  //   // return this._queryClassForName(query.name, variantName, variantFn)._create(props);
-  // },
-
   _createQueryForRelation(_relation, variant) {
-    let name = _relation.relationship.opts.query;
-    if(!name) {
+    let query = _relation.relationship.opts.query;
+    if(!query) {
       let relationship = _relation.getValue();
-      name = relationship.get('query');
+      query = relationship.get('query');
     }
-    return this._createQueryForName({
-      name,
+    return this._createQuery({
+      query,
       variant,
       props: { _relation }
     });
@@ -47,12 +47,12 @@ export default Ember.Mixin.create({
 
   _createQueryForInternalCollection(_internalCollection, variant) {
     let collection = _internalCollection.getCollectionModel();
-    let name = collection.get('query') || collection.get('queryName');
-    if(!name) {
+    let query = collection.get('query') || collection.get('queryName');
+    if(!query) {
       return;
     }
-    return this._createQueryForName({
-      name,
+    return this._createQuery({
+      query,
       variant,
       props: { _internalCollection }
     });

--- a/addon/store/store-query.js
+++ b/addon/store/store-query.js
@@ -1,25 +1,54 @@
 import Ember from 'ember';
 
+const {
+  merge
+} = Ember;
+
 export default Ember.Mixin.create({
 
+  _createQueryForName(query, props, variantName, variantFn) {
+    let factoryOptions = {};
+    return this._queryClassForName(query, factoryOptions, variantName, variantFn)._create(props);
+  },
+
+  _buildQueryFactoryOptions(query) {
+    if(typeof query === 'string') {
+      return {
+        name: query
+      };
+    };
+    return query;
+  },
+
+  _queryIdentifier(variant, opts) {
+    return `${variant} ${JSON.stringify(opts)}`;
+  },
+
+  _createQuery(query, props, variant, fn) {
+    let opts = merge({}, this._buildQueryFactoryOptions(query));
+    let name = opts.name;
+    delete opts.name;
+    // variant = this._queryIdentifier(variant, opts);
+    return this._createQueryForName(name, props, variant, fn);
+    // return this._queryClassForName(query.name, variantName, variantFn)._create(props);
+  },
+
   _createQueryForRelation(_relation, variantName, variantFn) {
-    let queryModelName = _relation.relationship.opts.query;
-    if(!queryModelName) {
+    let query = _relation.relationship.opts.query;
+    if(!query) {
       let relationship = _relation.getValue();
-      queryModelName = relationship.get('query');
+      query = relationship.get('query');
     }
-    let Query = this._queryClassForName(queryModelName, variantName, variantFn);
-    return Query._create({ _relation });
+    return this._createQuery(query, { _relation }, variantName, variantFn);
   },
 
   _createQueryForInternalCollection(_internalCollection, variantName, variantFn) {
     let collection = _internalCollection.getCollectionModel();
-    let queryModelName = collection.get('queryName');
-    if(!queryModelName) {
+    let query = collection.get('queryName');
+    if(!query) {
       return;
     }
-    let Query = this._queryClassForName(queryModelName, variantName, variantFn);
-    return Query._create({ _internalCollection });
+    return this._createQuery(query, { _internalCollection }, variantName, variantFn);
   }
 
 });

--- a/tests/unit/has-many-loaded-relationship-query-factory-test.js
+++ b/tests/unit/has-many-loaded-relationship-query-factory-test.js
@@ -144,7 +144,7 @@ configurations(({ module, test, createStore }) => {
     });
   });
 
-  test.only('query in relationship opts', assert => {
+  test('query in relationship opts', assert => {
     let Hamster = Model.extend({
       id: prefix(),
       building: belongsTo('building', { inverse: 'hamsters' })

--- a/tests/unit/has-many-loaded-relationship-query-factory-test.js
+++ b/tests/unit/has-many-loaded-relationship-query-factory-test.js
@@ -1,0 +1,183 @@
+/* global emit */
+import Ember from 'ember';
+import { configurations, registerModels, registerQueries, registerRelationships, cleanup } from '../helpers/setup';
+import { Relationship, Query, Model, prefix, belongsTo, hasMany } from 'sofa';
+import HasManyLoaded from 'sofa/properties/relations/has-many-loaded';
+
+const {
+  computed,
+  RSVP: { all }
+} = Ember;
+
+const ducks_ddoc = {
+  views: {
+    'by-house': {
+      map(doc) {
+        if(doc.type !== 'duck') {
+          return;
+        }
+        emit(doc.house, null);
+      }
+    }
+  }
+};
+
+const hamsters_ddoc = {
+  views: {
+    'all': {
+      map(doc) {
+        if(doc.type !== 'hamster') {
+          return;
+        }
+        emit(doc._id, null);
+      }
+    }
+  }
+};
+
+configurations(({ module, test, createStore }) => {
+
+  let store;
+  let db;
+
+  let ViewByKey = opts => {
+    let { ddoc, view, dep } = opts;
+    return Query.extend({
+      find: computed(dep, function() {
+        let key = this.get(dep);
+        return { ddoc, view, key };
+      })
+    });
+  };
+
+  let HouseDucksRelationship = Relationship.extend({
+    query: { name: 'view-by-key', ddoc: 'ducks', view: 'by-house', key: 'model.docId' },
+  });
+
+  let Duck = Model.extend({
+    id: prefix(),
+    house: belongsTo('house', { inverse: 'ducks' })
+  });
+
+  let House = Model.extend({
+    id: prefix(),
+    ducks: hasMany('duck', { inverse: 'house', relationship: 'house-ducks' }),
+  });
+
+  function flush() {
+    store = createStore();
+    db = store.get('db.main');
+    db.set('modelNames', [ 'duck', 'house' ]);
+  }
+
+  module('has-many-loaded-relationship-query-factory', () => {
+    registerModels({ Duck, House });
+    registerQueries({ ViewByKey });
+    registerRelationships({ HouseDucks: HouseDucksRelationship });
+    flush();
+    return cleanup(store, [ 'main' ]).then(() => {
+      return all([
+        db.get('documents.design').save('ducks', ducks_ddoc),
+        db.get('documents.design').save('hamsters', hamsters_ddoc),
+      ]);
+    });
+  });
+
+  test('ducks are HasManyLoaded relation', assert => {
+    let house = db.model('house');
+    assert.ok(house.get('ducks')._relation.constructor === HasManyLoaded);
+  });
+
+  test('has many with query in relationship is not persisted', assert => {
+    let house = db.model('house', { id: 'big' });
+    let ducks = [ 'yellow', 'green', 'red' ].map(id => db.model('duck', { id, house }));
+    return all([ house.save(), all(ducks.map(duck => duck.save())) ]).then(() => {
+      return db.get('documents').load('house:big');
+    }).then(doc => {
+      assert.deepEqual_(doc, {
+        "_id": "house:big",
+        "_rev": "ignored",
+        "type": "house"
+      });
+    });
+  });
+
+  test('update query prop marks relationship for reload', assert => {
+    let Hamster = Model.extend({
+      id: prefix(),
+      building: belongsTo('building', { inverse: 'hamsters' })
+    });
+
+    let Building = Model.extend({
+      id: prefix(),
+      hamsters: hasMany('hamster', { inverse: 'building', relationship: 'hamster-buildings' }),
+    });
+
+    let HamsterBuildings = Relationship.extend({
+      query: { name: 'hamster-buildings', keys: [ 'hamster:green', 'hamster:red' ] }
+    });
+
+    let HamsterBuildingsQuery = opts => Query.extend({
+      find: computed(function() {
+        return { ddoc: 'hamsters', view: 'all', keys: opts.keys };
+      })
+    });
+
+    registerModels({ Hamster, Building });
+    registerRelationships({ HamsterBuildings });
+    registerQueries({ HamsterBuildings: HamsterBuildingsQuery });
+
+    let building = db.model('building', { id: 'big' });
+    let hamsters = [ 'yellow', 'green', 'red' ].map(id => db.model('hamster', { id, building }));
+    return all([ building.save(), all(hamsters.map(duck => duck.save())) ]).then(() => {
+      flush();
+      return db.load('building', 'big');
+    }).then(building_ => {
+      building = building_;
+      return building.get('hamsters.promise');
+    }).then(hamsters => {
+      assert.deepEqual(hamsters.mapBy('id'), [ "green", "red" ]);
+      building.set('hamsters.query', { name: 'hamster-buildings', keys: [ 'hamster:yellow' ] });
+      return hamsters.get('promise');
+    }).then(hamsters => {
+      assert.deepEqual(hamsters.mapBy('id'), [ "yellow" ]);
+    });
+  });
+
+  test.only('query in relationship opts', assert => {
+    let Hamster = Model.extend({
+      id: prefix(),
+      building: belongsTo('building', { inverse: 'hamsters' })
+    });
+
+    let Building = Model.extend({
+      id: prefix(),
+      hamsters: hasMany('hamster', {
+        inverse: 'building',
+        query: { name: 'hamster-buildings', keys: [ 'hamster:green', 'hamster:red' ] }
+      }),
+    });
+
+    let HamsterBuildingsQuery = opts => Query.extend({
+      find: computed(function() {
+        return { ddoc: 'hamsters', view: 'all', keys: opts.keys };
+      })
+    });
+
+    registerModels({ Hamster, Building });
+    registerQueries({ HamsterBuildings: HamsterBuildingsQuery });
+
+    let building = db.model('building', { id: 'big' });
+    let hamsters = [ 'yellow', 'green', 'red' ].map(id => db.model('hamster', { id, building }));
+    return all([ building.save(), all(hamsters.map(duck => duck.save())) ]).then(() => {
+      flush();
+      return db.load('building', 'big');
+    }).then(building_ => {
+      building = building_;
+      return building.get('hamsters.promise');
+    }).then(hamsters => {
+      assert.deepEqual(hamsters.mapBy('id'), [ "green", "red" ]);
+    });
+  });
+
+});

--- a/tests/unit/query-create-test.js
+++ b/tests/unit/query-create-test.js
@@ -1,49 +1,67 @@
-import Ember from 'ember';
-import { configurations, registerModels, registerCollections, registerQueries, cleanup } from '../helpers/setup';
-import { Model, Collection, Query, prefix, type } from 'sofa';
+import { registerQueries, module, test, createStore } from '../helpers/setup';
+import { Query } from 'sofa';
 
-const {
-  computed,
-  RSVP: { all }
-} = Ember;
+let store;
+let classes;
 
-configurations(({ module, test, createStore }) => {
+module('query-create', () => {
+  store = createStore();
+  classes = store.get('_classes');
+});
 
-  let store;
-  let classes;
-
-  // let Sections = Collection.extend({
-  //   modelName: 'section',
-  //   query: { name: 'all-sections', ddoc: 'section', view: 'all' }
-  // });
-
-  module('query-create', () => {
-    store = createStore();
-    classes = store.get('_classes');
+test('create query with string', assert => {
+  let Thing = Query.extend({
+    info: 'this'
   });
-
-  test('create plain query', assert => {
-    let Thing = Query.extend({
-      info: 'this'
-    });
-    registerQueries({ Thing });
-    let query = store._createQueryForName('thing', {}, 'main', Query => Query);
-    assert.ok(query);
-    assert.ok(query.get('info') === 'this');
-    assert.ok(classes['query:thing:-base']);
-    assert.ok(classes['query:thing:main']);
+  registerQueries({ Thing });
+  let query = store._createQuery({
+    query: 'thing',
+    variant: {
+      name: 'main',
+      prepare: Query => Query
+    }
   });
+  assert.ok(query);
+  assert.ok(query.get('info') === 'this');
+  assert.ok(classes['query:thing:-base']);
+  assert.ok(classes['query:thing:main']);
+});
 
-  test('create query using factory', assert => {
-    let Thing = opts => Query.extend({
-      info: opts.info
-    });
-    registerQueries({ Thing });
-    let query = store._createQuery({ name: 'thing', info: 'this' }, {}, 'main', Query => Query);
-    // assert.ok(query);
-    // assert.ok(query.get('info') === 'this');
-    // assert.ok(classes['query:thing:-base']);
-    // assert.ok(classes['query:thing:main']);
+test('create query factory with string', assert => {
+  let Thing = () => Query.extend({
+    info: 'this'
   });
+  registerQueries({ Thing });
+  let query = store._createQuery({
+    query: 'thing',
+    variant: {
+      name: 'main',
+      prepare: Query => Query
+    }
+  });
+  assert.ok(query);
+  assert.ok(query.get('info') === 'this');
+  assert.ok(classes['query:thing:-base']);
+  assert.ok(classes['query:thing:main']);
+});
 
+test('create query factory with options', assert => {
+  let Thing = opts => Query.extend({
+    info: opts.info
+  });
+  registerQueries({ Thing });
+  let query = store._createQuery({
+    query: {
+      name: 'thing',
+      info: 'that'
+    },
+    variant: {
+      name: 'main',
+      prepare: Query => Query
+    }
+  });
+  assert.ok(query);
+  assert.ok(query.get('info') === 'that');
+  assert.ok(classes['query:thing:{"info":"that"}:-base']);
+  assert.ok(classes['query:thing:{"info":"that"}:main']);
 });

--- a/tests/unit/query-create-test.js
+++ b/tests/unit/query-create-test.js
@@ -1,0 +1,49 @@
+import Ember from 'ember';
+import { configurations, registerModels, registerCollections, registerQueries, cleanup } from '../helpers/setup';
+import { Model, Collection, Query, prefix, type } from 'sofa';
+
+const {
+  computed,
+  RSVP: { all }
+} = Ember;
+
+configurations(({ module, test, createStore }) => {
+
+  let store;
+  let classes;
+
+  // let Sections = Collection.extend({
+  //   modelName: 'section',
+  //   query: { name: 'all-sections', ddoc: 'section', view: 'all' }
+  // });
+
+  module('query-create', () => {
+    store = createStore();
+    classes = store.get('_classes');
+  });
+
+  test('create plain query', assert => {
+    let Thing = Query.extend({
+      info: 'this'
+    });
+    registerQueries({ Thing });
+    let query = store._createQueryForName('thing', {}, 'main', Query => Query);
+    assert.ok(query);
+    assert.ok(query.get('info') === 'this');
+    assert.ok(classes['query:thing:-base']);
+    assert.ok(classes['query:thing:main']);
+  });
+
+  test('create query using factory', assert => {
+    let Thing = opts => Query.extend({
+      info: opts.info
+    });
+    registerQueries({ Thing });
+    let query = store._createQuery({ name: 'thing', info: 'this' }, {}, 'main', Query => Query);
+    // assert.ok(query);
+    // assert.ok(query.get('info') === 'this');
+    // assert.ok(classes['query:thing:-base']);
+    // assert.ok(classes['query:thing:main']);
+  });
+
+});

--- a/tests/unit/query-create-test.js
+++ b/tests/unit/query-create-test.js
@@ -65,3 +65,38 @@ test('create query factory with options', assert => {
   assert.ok(classes['query:thing:{"info":"that"}:-base']);
   assert.ok(classes['query:thing:{"info":"that"}:main']);
 });
+
+test('create query factory with options class is cached', assert => {
+  let Thing = opts => Query.extend({
+    info: opts.info
+  });
+  registerQueries({ Thing });
+
+  let one = store._createQuery({
+    query: {
+      name: 'thing',
+      info: 'that'
+    },
+    variant: {
+      name: 'main',
+      prepare: Query => Query
+    }
+  }).constructor;
+
+  let two = store._createQuery({
+    query: {
+      name: 'thing',
+      info: 'that'
+    },
+    variant: {
+      name: 'main',
+      prepare: Query => Query
+    }
+  }).constructor;
+
+  assert.ok(one !== two);
+  assert.ok(one.constructor === two.constructor);
+
+  assert.ok(classes['query:thing:{"info":"that"}:-base']);
+  assert.ok(classes['query:thing:{"info":"that"}:main']);
+});

--- a/tests/unit/query-create-test.js
+++ b/tests/unit/query-create-test.js
@@ -81,7 +81,7 @@ test('create query factory with options class is cached', assert => {
       name: 'main',
       prepare: Query => Query
     }
-  }).constructor;
+  });
 
   let two = store._createQuery({
     query: {
@@ -92,7 +92,7 @@ test('create query factory with options class is cached', assert => {
       name: 'main',
       prepare: Query => Query
     }
-  }).constructor;
+  });
 
   assert.ok(one !== two);
   assert.ok(one.constructor === two.constructor);


### PR DESCRIPTION
Allows to declare query as a function which returns Query subclass

``` javascript
// queries/view-by-key.js
export default opts => {
  let { ddoc, view, dep } = opts;
  return Query.extend({
    find: computed(dep, function() {
      let key = this.get(dep);
      return { ddoc, view, key };
    }).readOnly()
  });
};
```

``` javascript
// relationships/house-ducks.js
export default Relationship.extend({

  query: { name: 'view-by-key', ddoc: 'ducks', view: 'by-house', key: 'model.docId' },

});
```
or
``` javascript
// models/house-ducks.js
export default Model.extend({
  
  ducks: hasMany('duck', { 
    inverse: 'house', 
    query: { 
      name: 'view-by-key', 
      ddoc: 'ducks', 
      view: 'by-house', 
      key: 'model.docId'
    }
  }
  
});
```